### PR TITLE
Feature/twcookie 28 import export settings/twcookie 33 handover issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixed
+
+- Potential Dataleak prevented
+
 ### Refactor
 
 - Fixed typos in multiple files

--- a/src/Acf/AcfCookies.php
+++ b/src/Acf/AcfCookies.php
@@ -150,4 +150,14 @@ class AcfCookies implements AcfGroupInterface
             AcfUtility::deleteAcfFieldRecursively($field, 'option');
         });
     }
+
+    /**
+     * get Field Names of Group
+     *
+     * @return array
+     */
+    public static function getFieldNames(): array
+    {
+        return collect((new AcfCookies())->buildFields())->pluck('name')->all();
+    }
 }

--- a/src/Acf/AcfGroupInterface.php
+++ b/src/Acf/AcfGroupInterface.php
@@ -23,4 +23,9 @@ interface AcfGroupInterface
      * deletes all fields of group
      */
     public static function deleteFields(): void;
+
+    /**
+     * get all field names of group
+     */
+    public static function getFieldNames(): array;
 }

--- a/src/Acf/AcfSettings.php
+++ b/src/Acf/AcfSettings.php
@@ -163,4 +163,14 @@ class AcfSettings implements AcfGroupInterface
             AcfUtility::deleteAcfFieldRecursively($field, 'option');
         });
     }
+
+    /**
+     * get Field Names of Group
+     *
+     * @return array
+     */
+    public static function getFieldNames(): array
+    {
+        return collect((new AcfSettings())->buildFields())->pluck('name')->all();
+    }
 }

--- a/src/Helper/PluginHelper.php
+++ b/src/Helper/PluginHelper.php
@@ -102,6 +102,7 @@ class PluginHelper
 
     /**
      * @return string
+     * @throws \Exception
      */
     public static function getDataPath()
     {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -393,6 +393,19 @@ class Plugin
     }
 
     /**
+     * Get all Plugin ACF Options
+     */
+    public static function getAcfOptions(): array
+    {
+        $data = \get_fields('options');
+        $fieldNames = array_merge(
+            AcfCookies::getFieldNames(),
+            AcfSettings::getFieldNames()
+        );
+        return collect($data)->only($fieldNames)->all();
+    }
+
+    /**
      * Return Settings.
      */
     public static function getData(): array
@@ -400,7 +413,8 @@ class Plugin
         $transientKey = self::getTransientKey();
         $data = \get_transient($transientKey);
         if (!$data) {
-            $data = \get_fields('options');
+            $data = self::getAcfOptions();
+
             // transient valid for one month
             \set_transient($transientKey, $data, 60 * 60 * 24 * 30);
         }


### PR DESCRIPTION
## TLDR; 

* only send data from the plugin to the frontend

## What to test & how to test 

* if other acf options are present, they are not included anymore.

## solves Issues
* prevents potential data leak

## Aditional Information:
* Applies if other ACF Option Pages than towa-gdpr-plugin are present. get_fields('option') would return them as well. Through handover to the frontend these would be exposed in a javascript object in the frontend.
+ ran phpcs