### PR TITLE
fix: load plugin when dom is ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Potential Dataleak prevented
+- Plugin load when DOM is ready
 
 ### Refactor
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -149,4 +149,6 @@ class TowaGdprPlugin {
 }
 
 // eslint-disable-next-line
-const towagdpr = new TowaGdprPlugin()
+document.addEventListener("DOMContentLoaded", () =>{
+  const towagdpr = new TowaGdprPlugin()
+});


### PR DESCRIPTION
## TLDR; 

* added event listener so the plugin loads when the DOM element is ready.

## What to test & how to test 

* install the plugin
* see if the plugin works like usual

## solves Issues
* plugin now loads when everything else is loaded.